### PR TITLE
refactor: use html-to-image to generate image

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "balm-ui": "^10.15.0",
-    "canvg": "^4.0.1",
+    "html-to-image": "^1.11.11",
     "jsbarcode": "^3.11.5",
     "kjua": "^0.9.0",
     "moment": "^2.29.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,51 +1,60 @@
-lockfileVersion: 5.4
-
-specifiers:
-  '@vitejs/plugin-vue': ^4.0.0
-  autoprefixer: ^10.4.13
-  balm-ui: ^10.15.0
-  canvg: ^4.0.1
-  jsbarcode: ^3.11.5
-  kjua: ^0.9.0
-  moment: ^2.29.4
-  postcss: ^8.4.21
-  tailwindcss: ^3.2.4
-  vite: ^4.1.0
-  vue: ^3.2.45
+lockfileVersion: '6.0'
 
 dependencies:
-  balm-ui: 10.15.0_vue@3.2.47
-  canvg: 4.0.1
-  jsbarcode: 3.11.5
-  kjua: 0.9.0
-  moment: 2.29.4
-  vue: 3.2.47
+  balm-ui:
+    specifier: ^10.15.0
+    version: 10.15.0(vue@3.2.47)
+  html-to-image:
+    specifier: ^1.11.11
+    version: 1.11.11
+  jsbarcode:
+    specifier: ^3.11.5
+    version: 3.11.5
+  kjua:
+    specifier: ^0.9.0
+    version: 0.9.0
+  moment:
+    specifier: ^2.29.4
+    version: 2.29.4
+  vue:
+    specifier: ^3.2.45
+    version: 3.2.47
 
 devDependencies:
-  '@vitejs/plugin-vue': 4.0.0_vite@4.1.1+vue@3.2.47
-  autoprefixer: 10.4.13_postcss@8.4.21
-  postcss: 8.4.21
-  tailwindcss: 3.2.4_postcss@8.4.21
-  vite: 4.1.1
+  '@vitejs/plugin-vue':
+    specifier: ^4.0.0
+    version: 4.0.0(vite@4.1.1)(vue@3.2.47)
+  autoprefixer:
+    specifier: ^10.4.13
+    version: 10.4.13(postcss@8.4.21)
+  postcss:
+    specifier: ^8.4.21
+    version: 8.4.21
+  tailwindcss:
+    specifier: ^3.2.4
+    version: 3.2.4(postcss@8.4.21)
+  vite:
+    specifier: ^4.1.0
+    version: 4.1.1
 
 packages:
 
-  /@babel/helper-string-parser/7.19.4:
+  /@babel/helper-string-parser@7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-validator-identifier/7.19.1:
+  /@babel/helper-validator-identifier@7.19.1:
     resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/parser/7.20.15:
+  /@babel/parser@7.20.15:
     resolution: {integrity: sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
       '@babel/types': 7.20.7
 
-  /@babel/types/7.20.7:
+  /@babel/types@7.20.7:
     resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
     engines: {node: '>=6.9.0'}
     dependencies:
@@ -53,16 +62,7 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
-  /@esbuild/android-arm/0.16.17:
-    resolution: {integrity: sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm64/0.16.17:
+  /@esbuild/android-arm64@0.16.17:
     resolution: {integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==}
     engines: {node: '>=12'}
     cpu: [arm64]
@@ -71,7 +71,16 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64/0.16.17:
+  /@esbuild/android-arm@0.16.17:
+    resolution: {integrity: sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.16.17:
     resolution: {integrity: sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -80,7 +89,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64/0.16.17:
+  /@esbuild/darwin-arm64@0.16.17:
     resolution: {integrity: sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==}
     engines: {node: '>=12'}
     cpu: [arm64]
@@ -89,7 +98,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64/0.16.17:
+  /@esbuild/darwin-x64@0.16.17:
     resolution: {integrity: sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -98,7 +107,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64/0.16.17:
+  /@esbuild/freebsd-arm64@0.16.17:
     resolution: {integrity: sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==}
     engines: {node: '>=12'}
     cpu: [arm64]
@@ -107,7 +116,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64/0.16.17:
+  /@esbuild/freebsd-x64@0.16.17:
     resolution: {integrity: sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -116,16 +125,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm/0.16.17:
-    resolution: {integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm64/0.16.17:
+  /@esbuild/linux-arm64@0.16.17:
     resolution: {integrity: sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==}
     engines: {node: '>=12'}
     cpu: [arm64]
@@ -134,7 +134,16 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32/0.16.17:
+  /@esbuild/linux-arm@0.16.17:
+    resolution: {integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.16.17:
     resolution: {integrity: sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==}
     engines: {node: '>=12'}
     cpu: [ia32]
@@ -143,7 +152,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64/0.16.17:
+  /@esbuild/linux-loong64@0.16.17:
     resolution: {integrity: sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
@@ -152,7 +161,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el/0.16.17:
+  /@esbuild/linux-mips64el@0.16.17:
     resolution: {integrity: sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==}
     engines: {node: '>=12'}
     cpu: [mips64el]
@@ -161,7 +170,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64/0.16.17:
+  /@esbuild/linux-ppc64@0.16.17:
     resolution: {integrity: sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==}
     engines: {node: '>=12'}
     cpu: [ppc64]
@@ -170,7 +179,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64/0.16.17:
+  /@esbuild/linux-riscv64@0.16.17:
     resolution: {integrity: sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==}
     engines: {node: '>=12'}
     cpu: [riscv64]
@@ -179,7 +188,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x/0.16.17:
+  /@esbuild/linux-s390x@0.16.17:
     resolution: {integrity: sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==}
     engines: {node: '>=12'}
     cpu: [s390x]
@@ -188,7 +197,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64/0.16.17:
+  /@esbuild/linux-x64@0.16.17:
     resolution: {integrity: sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -197,7 +206,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64/0.16.17:
+  /@esbuild/netbsd-x64@0.16.17:
     resolution: {integrity: sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -206,7 +215,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64/0.16.17:
+  /@esbuild/openbsd-x64@0.16.17:
     resolution: {integrity: sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -215,7 +224,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64/0.16.17:
+  /@esbuild/sunos-x64@0.16.17:
     resolution: {integrity: sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -224,7 +233,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64/0.16.17:
+  /@esbuild/win32-arm64@0.16.17:
     resolution: {integrity: sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==}
     engines: {node: '>=12'}
     cpu: [arm64]
@@ -233,7 +242,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32/0.16.17:
+  /@esbuild/win32-ia32@0.16.17:
     resolution: {integrity: sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==}
     engines: {node: '>=12'}
     cpu: [ia32]
@@ -242,7 +251,7 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64/0.16.17:
+  /@esbuild/win32-x64@0.16.17:
     resolution: {integrity: sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==}
     engines: {node: '>=12'}
     cpu: [x64]
@@ -251,20 +260,20 @@ packages:
     dev: true
     optional: true
 
-  /@material/animation/15.0.0-canary.d9f821042.0:
+  /@material/animation@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-AEmSKACQBtSCWobrt4llzjWInHYuW6KeOHMeL+3atqZEM/2LoqZocALsnGoHCLFfhiZuOPqMUyKodXdda5byZg==}
     dependencies:
       tslib: 2.5.0
     dev: false
 
-  /@material/auto-init/15.0.0-canary.d9f821042.0:
+  /@material/auto-init@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-Jjh4oCU4ZvPww4Wuwsr7yZ3y1BbOBK+8bDF3jk2yZHQojDUwNXXCKqh6g0Fei0o7chT3zNtMNu9L22yRy+A1ig==}
     dependencies:
       '@material/base': 15.0.0-canary.d9f821042.0
       tslib: 2.5.0
     dev: false
 
-  /@material/banner/15.0.0-canary.d9f821042.0:
+  /@material/banner@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-ZbTUpIDoHNbnxA2FfdSxEsAOr1ZS/ob8Q9vYd7HLUTzG67f1Q2JnOJxPm1Bcp9FxQw71rRI+06s38RMLiScaMg==}
     dependencies:
       '@material/base': 15.0.0-canary.d9f821042.0
@@ -281,13 +290,13 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/base/15.0.0-canary.d9f821042.0:
+  /@material/base@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-A6nt4c+2NHcNqOmacI3Ub6jCKLnW2c+w4Ur0H5Ly3gqbrIvSg8UhtG/xZKm/NsdXQG+HuXCgUt+6R8tIl0IIJA==}
     dependencies:
       tslib: 2.5.0
     dev: false
 
-  /@material/button/15.0.0-canary.d9f821042.0:
+  /@material/button@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-MNvVgvEu2GxnlXIBbeW15nJwXNG2Hs2+DKMNZrbPoWBo61JZKP6C6ygTMhLJcQD/MHVR2xQz5RQqC1+dBl8GMA==}
     dependencies:
       '@material/density': 15.0.0-canary.d9f821042.0
@@ -305,7 +314,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/card/15.0.0-canary.d9f821042.0:
+  /@material/card@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-d42VCqniHK8XepHxYxYsO2ZYSvgJMS/3JqYDvkitoNGOxl2XkfD9ozVfkhZ1CiWDOrG1xZgZ7y41+SrPSVoDXQ==}
     dependencies:
       '@material/dom': 15.0.0-canary.d9f821042.0
@@ -319,7 +328,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/checkbox/15.0.0-canary.d9f821042.0:
+  /@material/checkbox@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-PLSCWvEpeuREXVXq7wU5AdskLu2LxY6VCuwG0arF72wXoPiYDl+H4haLlVRvBEvXYQdN/1JIDkBwoCwHMOpLTA==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -334,7 +343,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/chips/15.0.0-canary.d9f821042.0:
+  /@material/chips@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-hDtEmG9f3keWOgqOZoH7Ka08+2EgKGHnx7Wk9NWnswS1gtH7pzts46nwA7+F9nhS1gVBPbrzrb1+2dZkUc7Apg==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -356,7 +365,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/circular-progress/15.0.0-canary.d9f821042.0:
+  /@material/circular-progress@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-Jh0RvWWYXy30Mq8bSjba5TjAEvuo2UHFqv7KQK1xgqNyueN9b/clRFG7rziCBwQsz1akcY6WhSrd7zDHkVJffw==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -369,7 +378,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/data-table/15.0.0-canary.d9f821042.0:
+  /@material/data-table@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-DLXRieukVofxp7DU6u6uuTdfNireiDl3CEiFOHo4Mvwv5VM66l2rOqljsnGG2TzScuqtrWcGteBoX3YXIChfRg==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -393,13 +402,13 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/density/15.0.0-canary.d9f821042.0:
+  /@material/density@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-xMBU4gThRSFqa+39Bzf35Xdjwdg2l8Ou/DUs0nacfdbUEgtePhw0r6Tej6kk1i9oJzw8AEQkdoA0ZrxrzfH0Bw==}
     dependencies:
       tslib: 2.5.0
     dev: false
 
-  /@material/dialog/15.0.0-canary.d9f821042.0:
+  /@material/dialog@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-kW3UYV2z8aB3Axv35i9od9tYYkON/MJ7Z6sZwtL3d6nA94R3U+6645s9cwjh+xO47OwZZw1pc6+brDwl/dE03Q==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -419,7 +428,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/dom/15.0.0-canary.d9f821042.0:
+  /@material/dom@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-3F3T3V7mSnpzk7gwTPGiOyWXTrElQfNEKg9s8S+nS9ewkaQ4Qx4mRqK/5hA+66zPmVhGSufIqHUT2ThHzoNmTA==}
     dependencies:
       '@material/feature-targeting': 15.0.0-canary.d9f821042.0
@@ -427,7 +436,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/drawer/15.0.0-canary.d9f821042.0:
+  /@material/drawer@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-aBDfvyssSUDalPAl6+Iz7QKntvNtq4ZhepVsCWJXsQV3UzmWO/vZkTuu4j8B5cFjF4yCVBXk+AXzRwYbkm5V9Q==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -444,7 +453,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/elevation/15.0.0-canary.d9f821042.0:
+  /@material/elevation@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-UJPZUJw/oPtvslNG4Qo9AvJYF/STlJg+NIAdcCZMXn5GPRgJULEKaTjli5L4JNLZk3jc/2855ZzOz095BUB1Dg==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -455,7 +464,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/fab/15.0.0-canary.d9f821042.0:
+  /@material/fab@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-2JN/uzCrmCAcQuY5klZEQ8/qiB/mXOx9tnniqBslxaC7sQHQbNjiCWyToiIvEjoWVS+P8OdNqnoV4xknw8qYnA==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -473,13 +482,13 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/feature-targeting/15.0.0-canary.d9f821042.0:
+  /@material/feature-targeting@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-OYxRQtkdm2ACZtVwDQ+/ebQxZFc3/HpMbuwZq6EpCmBYl6J9RO3eaC92h2lTpPSTBDoi8j9STRrt7v+NX2HT+Q==}
     dependencies:
       tslib: 2.5.0
     dev: false
 
-  /@material/floating-label/15.0.0-canary.d9f821042.0:
+  /@material/floating-label@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-4V4Ehm4ImnyYORIDrllizSLax1RO+B1UuXTCVLgq0f7DsW34nJy0P0o9aagvECEs/8KMMv9vnCvtUSNB8rU0nQ==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -492,7 +501,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/focus-ring/15.0.0-canary.d9f821042.0:
+  /@material/focus-ring@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-2anJorHg6A+Ldtnm2ODQXClvf4UaOiut/VByWL49qAivXWpR3kTXYYHirkzF9lyWKBUpu52v2A7ugFvL6R99/g==}
     dependencies:
       '@material/dom': 15.0.0-canary.d9f821042.0
@@ -500,14 +509,14 @@ packages:
       '@material/rtl': 15.0.0-canary.d9f821042.0
     dev: false
 
-  /@material/focus/15.0.0-canary.d9f821042.0:
+  /@material/focus@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-iXCpVnvEidVkAyxERkGeVfYd8GVj+1hTPgH9X0ljDaWlnRN3LryMCv1WakrGiTwCJfQ3pPqhulnSravsicKMxA==}
     dependencies:
       '@material/theme': 15.0.0-canary.d9f821042.0
       '@material/tokens': 15.0.0-canary.d9f821042.0
     dev: false
 
-  /@material/form-field/15.0.0-canary.d9f821042.0:
+  /@material/form-field@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-zGj/LN1IxQ6xWeuhNd6aKZFqCjcAFi+a2Pqe9OQgdDjxw7uFTnoTPEqtHlKPudi0zhdTs69Q6w1x9+gIyjA/ug==}
     dependencies:
       '@material/base': 15.0.0-canary.d9f821042.0
@@ -519,7 +528,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/icon-button/15.0.0-canary.d9f821042.0:
+  /@material/icon-button@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-SgqlucaBbQcOaHp4P8m5R/hQks2hqfbYHnnmih+zNFBVtrh3/nuCV//dAFM/o+oEQ4rxjN0LODvl9D/BYIS/Jw==}
     dependencies:
       '@material/base': 15.0.0-canary.d9f821042.0
@@ -535,7 +544,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/image-list/15.0.0-canary.d9f821042.0:
+  /@material/image-list@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-m4IokuLDRAnxymLNPBSjq9p3Vjc/YwbdDxH2t7x07bdL2DkFjEznFKmLaXM7qPEHnKJymkhyPJqTDWl4Zgtthg==}
     dependencies:
       '@material/feature-targeting': 15.0.0-canary.d9f821042.0
@@ -545,13 +554,13 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/layout-grid/15.0.0-canary.d9f821042.0:
+  /@material/layout-grid@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-Rgg0L1OMP9vKiL04EKHGTdu71CSIG8e1yIbKc8JaImIK1KrgHH6eqymcC/lMu+enkOyEHZ0Xe5dsSKs3TIj06w==}
     dependencies:
       tslib: 2.5.0
     dev: false
 
-  /@material/line-ripple/15.0.0-canary.d9f821042.0:
+  /@material/line-ripple@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-nYpjNX/1gPyRR3Fj16M5LpWvCKpFVumFwH2fNa/6+MfbbGGOavHAbzViz81foW9/PifFA7QldW56hjafDTJsCw==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -561,7 +570,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/linear-progress/15.0.0-canary.d9f821042.0:
+  /@material/linear-progress@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-uGqbx0DfUMSz+8ppn+lIKqrYhSw+Mm/2TIy6nBGgW/Csi22nc6oAij9QQRc6g4jSuKnAP0RywOKasGS007CgXw==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -574,7 +583,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/list/15.0.0-canary.d9f821042.0:
+  /@material/list@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-y8j9UAsZoH/cX2Io+3qwfpBCx75nFoFFxRuUWcZSw6ldzytWqSyXjkjY28kTNlXh6ksGJrbxh4VtPA6KAwUzMA==}
     dependencies:
       '@material/base': 15.0.0-canary.d9f821042.0
@@ -590,7 +599,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/menu-surface/15.0.0-canary.d9f821042.0:
+  /@material/menu-surface@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-9Y4PAw5KI2XMB216hGwGD/+byHwnFwTFRlDB+i/jETEPwXOp/r2gMWCn4C8VOjc8JFBTHePjine0xZ5VrTKO9g==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -603,7 +612,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/menu/15.0.0-canary.d9f821042.0:
+  /@material/menu@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-LBmDV5xivkMPwuTa3YETUNrH/0MHynL4skzbKAMKkZv3e270uvBd/eXTQr6CWXxJpCk5PDYm/HB+Elrn8BJXTw==}
     dependencies:
       '@material/base': 15.0.0-canary.d9f821042.0
@@ -620,7 +629,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/notched-outline/15.0.0-canary.d9f821042.0:
+  /@material/notched-outline@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-a9JAzqUKAx3NWLytIj7dyRqGxs85vEJjTCoLF+cG+pTrFE8N02J/o3UAgYM5FtHPRie67YrKzncCTlxWGGTkQQ==}
     dependencies:
       '@material/base': 15.0.0-canary.d9f821042.0
@@ -632,13 +641,13 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/progress-indicator/15.0.0-canary.d9f821042.0:
+  /@material/progress-indicator@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-NQzaA20E74F2jcdF4U8Ljf3lnlzkcXbPyFuGvarsi4G62qUmkrvvhqZYoYcLfCoS5lOlwOXZcSttPAS6dt0vDQ==}
     dependencies:
       tslib: 2.5.0
     dev: false
 
-  /@material/radio/15.0.0-canary.d9f821042.0:
+  /@material/radio@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-CfbtPyGe5Odxc605kwv77rlz5Qki1qB5m3FibgaGSjWvpLD9mP2kEML2IYnj6OeunmX/DTjyZeT5KQ4LnjW1Ow==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -653,7 +662,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/ripple/15.0.0-canary.d9f821042.0:
+  /@material/ripple@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-C2XWKb3n3T1/KO9M7OpygcISwADIW93s6SU6OFFf2bQYFVXaP/j3MdGKoWV33Bm3kl8/rCqgtY9KA5y+V/cDog==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -665,14 +674,14 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/rtl/15.0.0-canary.d9f821042.0:
+  /@material/rtl@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-Y5Y35hN4cd9YAFOCJ+WsMbn4SfFHP2GK7NFqRYKnMoFaiOfgj2q3qGdTIK/S2eGESdWL+xbNkPsdVF5/GlBdqg==}
     dependencies:
       '@material/theme': 15.0.0-canary.d9f821042.0
       tslib: 2.5.0
     dev: false
 
-  /@material/segmented-button/15.0.0-canary.d9f821042.0:
+  /@material/segmented-button@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-4XAH60wIa5J8PkvQxC7sD9rACJ2+PyXFBYZ3G5dpNDgHWUltPpXOyCYuojXf+33K5sOUkGZLRx9VsGRXybFcnQ==}
     dependencies:
       '@material/base': 15.0.0-canary.d9f821042.0
@@ -685,7 +694,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/select/15.0.0-canary.d9f821042.0:
+  /@material/select@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-xISJLcnpZyD6CTFkoXPFcCZ8+kOtWG9m1CM3CE7GMpG9NMaMSp7ng04NtW+astyXAt3/YxOdXU6x409tiXUvNA==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -709,7 +718,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/shape/15.0.0-canary.d9f821042.0:
+  /@material/shape@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-VQNV7R6gkpS8AqlYBSbsLwzNwI9zRZ/lBOLbJ/8CKPNakOWNELnVSnFalnumKtpgn0S2zL+Ts/1Zh5RBYcIqeA==}
     dependencies:
       '@material/feature-targeting': 15.0.0-canary.d9f821042.0
@@ -718,7 +727,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/slider/15.0.0-canary.d9f821042.0:
+  /@material/slider@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-Hkky2LWOPAvewtgIwbzo4IyQxFHvUC1DtuVVNO4Ry+VoO5tVTaOy5diFZg4+pnlTIaB/RW4vQU2nZM8s2jvhZA==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -734,7 +743,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/snackbar/15.0.0-canary.d9f821042.0:
+  /@material/snackbar@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-XyOZmdtubsa1g3NkPAL5i41IRulDcmwmIMx/0dk+uiq3NeV6rU8bWeCXnACHocINyDCI3k/B0agfG9N7vke2RQ==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -753,7 +762,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/switch/15.0.0-canary.d9f821042.0:
+  /@material/switch@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-6hsIs/T7qqw2WhVNCrvBUACq5xXFUea6QbTjIGXoP+qJ2UqYm4qqoc3w2Wh5B7DLAKI9Xy9k3dt+15p6rAWcYg==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -772,7 +781,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/tab-bar/15.0.0-canary.d9f821042.0:
+  /@material/tab-bar@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-cQwSXSaU1zbghrWKo6q2tG8K8n9YNwRMIxafYEPgLfGlkX5toMYfAIGYMWhbTbqpOY2KsHPywj1zK8ualjfsTQ==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -789,7 +798,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/tab-indicator/15.0.0-canary.d9f821042.0:
+  /@material/tab-indicator@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-0KDXM26lIUktMQePi1pEB6adZjEyklxbrYZLSg3Z0dsVeEk/+BBFGJZDUHrTiwS4gfH5J3MnXcI8d+a3VjUnVw==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -799,7 +808,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/tab-scroller/15.0.0-canary.d9f821042.0:
+  /@material/tab-scroller@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-d5IASm+bwt1q/e9+n2h4Nc/nX722S8bFRqARhtC5uhN86IzTKUGTzQe6m/YlCgaPd4PKuiXyRns6W4U64/Nj7Q==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -810,7 +819,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/tab/15.0.0-canary.d9f821042.0:
+  /@material/tab@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-me267gb0+O8yKLATZWDMK1NpOzADRje8VYUxLEByjWtvvcQ+9s/dERoeOdDoZ2Qm31hxHuDJcHrPU5fgmOyltw==}
     dependencies:
       '@material/base': 15.0.0-canary.d9f821042.0
@@ -826,7 +835,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/textfield/15.0.0-canary.d9f821042.0:
+  /@material/textfield@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-gJTpDM/zCgZielO+0NpBgN0mk88Mfl7tZv9ZIkBb5kOOP8cseu3Dd1obxEuzUZ/+CAosyGk++3R5K6ExWXOV7Q==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -846,20 +855,20 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/theme/15.0.0-canary.d9f821042.0:
+  /@material/theme@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-N5FvEi0vdrIgJdTzeE1kROwRSyUtrTJTXdMxdoegnnIOF5Cv0DLsVF196yRW0FhMfiEDYn2QsEWxFnaxJUfvug==}
     dependencies:
       '@material/feature-targeting': 15.0.0-canary.d9f821042.0
       tslib: 2.5.0
     dev: false
 
-  /@material/tokens/15.0.0-canary.d9f821042.0:
+  /@material/tokens@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-t2dGszW63b520hUs3WAVSooYOR0F6ns0o4wLmF/RMfKA1d6sWszqMGwqlwps2fp63hpMyasODspte42Efgrznw==}
     dependencies:
       '@material/elevation': 15.0.0-canary.d9f821042.0
     dev: false
 
-  /@material/tooltip/15.0.0-canary.d9f821042.0:
+  /@material/tooltip@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-WUA3us7R3woPizZXqVrWrh8zKhjoQXNLGwrhzUplo52eRt9V5YH47tGIgefYUDaqcpEvr1lPaHEp6mUfKZhSwQ==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -877,7 +886,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/top-app-bar/15.0.0-canary.d9f821042.0:
+  /@material/top-app-bar@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-89RkHK+u9szGFlSUnnLuXcKXanHPMm4KHbTuh2p2AS8oS3hkiBsE9yIFO7QuEEKV9xY8AOg1R9qZDowKXtqLMQ==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -891,7 +900,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/touch-target/15.0.0-canary.d9f821042.0:
+  /@material/touch-target@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-kRrMJVKqUhnPy93W6whsiT/3E9dDtlZSFrIkdNBEeIK7yHvvZWVKDtwJJzB6Tdomq4vdbcfU9TqXKpjqrHme3g==}
     dependencies:
       '@material/base': 15.0.0-canary.d9f821042.0
@@ -901,7 +910,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@material/typography/15.0.0-canary.d9f821042.0:
+  /@material/typography@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-YfCaWPzlSLe1b1r1dRe+Y3s3V40deTlUKJ1yhPGG/DonY6O1ifzZ+qLLSoYh8piCbQJxFPekT78DHB8WlbNvqA==}
     dependencies:
       '@material/feature-targeting': 15.0.0-canary.d9f821042.0
@@ -909,7 +918,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@nodelib/fs.scandir/2.1.5:
+  /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
     dependencies:
@@ -917,12 +926,12 @@ packages:
       run-parallel: 1.2.0
     dev: true
 
-  /@nodelib/fs.stat/2.0.5:
+  /@nodelib/fs.stat@2.0.5:
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
     dev: true
 
-  /@nodelib/fs.walk/1.2.8:
+  /@nodelib/fs.walk@1.2.8:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
     dependencies:
@@ -930,15 +939,7 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@types/offscreencanvas/2019.7.0:
-    resolution: {integrity: sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==}
-    dev: false
-
-  /@types/raf/3.4.0:
-    resolution: {integrity: sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==}
-    dev: false
-
-  /@vitejs/plugin-vue/4.0.0_vite@4.1.1+vue@3.2.47:
+  /@vitejs/plugin-vue@4.0.0(vite@4.1.1)(vue@3.2.47):
     resolution: {integrity: sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -949,7 +950,7 @@ packages:
       vue: 3.2.47
     dev: true
 
-  /@vue/compiler-core/3.2.47:
+  /@vue/compiler-core@3.2.47:
     resolution: {integrity: sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==}
     dependencies:
       '@babel/parser': 7.20.15
@@ -957,13 +958,13 @@ packages:
       estree-walker: 2.0.2
       source-map: 0.6.1
 
-  /@vue/compiler-dom/3.2.47:
+  /@vue/compiler-dom@3.2.47:
     resolution: {integrity: sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==}
     dependencies:
       '@vue/compiler-core': 3.2.47
       '@vue/shared': 3.2.47
 
-  /@vue/compiler-sfc/3.2.47:
+  /@vue/compiler-sfc@3.2.47:
     resolution: {integrity: sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==}
     dependencies:
       '@babel/parser': 7.20.15
@@ -977,13 +978,13 @@ packages:
       postcss: 8.4.21
       source-map: 0.6.1
 
-  /@vue/compiler-ssr/3.2.47:
+  /@vue/compiler-ssr@3.2.47:
     resolution: {integrity: sha512-wVXC+gszhulcMD8wpxMsqSOpvDZ6xKXSVWkf50Guf/S+28hTAXPDYRTbLQ3EDkOP5Xz/+SY37YiwDquKbJOgZw==}
     dependencies:
       '@vue/compiler-dom': 3.2.47
       '@vue/shared': 3.2.47
 
-  /@vue/reactivity-transform/3.2.47:
+  /@vue/reactivity-transform@3.2.47:
     resolution: {integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==}
     dependencies:
       '@babel/parser': 7.20.15
@@ -992,25 +993,25 @@ packages:
       estree-walker: 2.0.2
       magic-string: 0.25.9
 
-  /@vue/reactivity/3.2.47:
+  /@vue/reactivity@3.2.47:
     resolution: {integrity: sha512-7khqQ/75oyyg+N/e+iwV6lpy1f5wq759NdlS1fpAhFXa8VeAIKGgk2E/C4VF59lx5b+Ezs5fpp/5WsRYXQiKxQ==}
     dependencies:
       '@vue/shared': 3.2.47
 
-  /@vue/runtime-core/3.2.47:
+  /@vue/runtime-core@3.2.47:
     resolution: {integrity: sha512-RZxbLQIRB/K0ev0K9FXhNbBzT32H9iRtYbaXb0ZIz2usLms/D55dJR2t6cIEUn6vyhS3ALNvNthI+Q95C+NOpA==}
     dependencies:
       '@vue/reactivity': 3.2.47
       '@vue/shared': 3.2.47
 
-  /@vue/runtime-dom/3.2.47:
+  /@vue/runtime-dom@3.2.47:
     resolution: {integrity: sha512-ArXrFTjS6TsDei4qwNvgrdmHtD930KgSKGhS5M+j8QxXrDJYLqYw4RRcDy1bz1m1wMmb6j+zGLifdVHtkXA7gA==}
     dependencies:
       '@vue/runtime-core': 3.2.47
       '@vue/shared': 3.2.47
       csstype: 2.6.21
 
-  /@vue/server-renderer/3.2.47_vue@3.2.47:
+  /@vue/server-renderer@3.2.47(vue@3.2.47):
     resolution: {integrity: sha512-dN9gc1i8EvmP9RCzvneONXsKfBRgqFeFZLurmHOveL7oH6HiFXJw5OGu294n1nHc/HMgTy6LulU/tv5/A7f/LA==}
     peerDependencies:
       vue: 3.2.47
@@ -1019,10 +1020,10 @@ packages:
       '@vue/shared': 3.2.47
       vue: 3.2.47
 
-  /@vue/shared/3.2.47:
+  /@vue/shared@3.2.47:
     resolution: {integrity: sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==}
 
-  /acorn-node/1.8.2:
+  /acorn-node@1.8.2:
     resolution: {integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==}
     dependencies:
       acorn: 7.4.1
@@ -1030,18 +1031,18 @@ packages:
       xtend: 4.0.2
     dev: true
 
-  /acorn-walk/7.2.0:
+  /acorn-walk@7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
     dev: true
 
-  /acorn/7.4.1:
+  /acorn@7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
 
-  /anymatch/3.1.3:
+  /anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
     dependencies:
@@ -1049,11 +1050,11 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /arg/5.0.2:
+  /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
     dev: true
 
-  /autoprefixer/10.4.13_postcss@8.4.21:
+  /autoprefixer@10.4.13(postcss@8.4.21):
     resolution: {integrity: sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
@@ -1069,7 +1070,7 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /balm-ui/10.15.0_vue@3.2.47:
+  /balm-ui@10.15.0(vue@3.2.47):
     resolution: {integrity: sha512-8tS7+gT+t0o4410YcmtAuf1unCObWRb8upJERkWurfkURG+78sINhmp3a0UHO+HVZdnZdzgXTdmbUGmg5iEG3A==}
     peerDependencies:
       vue: '>=3'
@@ -1081,19 +1082,19 @@ packages:
       vue: 3.2.47
     dev: false
 
-  /binary-extensions/2.2.0:
+  /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
     dev: true
 
-  /braces/3.0.2:
+  /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
     dev: true
 
-  /browserslist/4.21.5:
+  /browserslist@4.21.5:
     resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
@@ -1101,38 +1102,26 @@ packages:
       caniuse-lite: 1.0.30001451
       electron-to-chromium: 1.4.292
       node-releases: 2.0.10
-      update-browserslist-db: 1.0.10_browserslist@4.21.5
+      update-browserslist-db: 1.0.10(browserslist@4.21.5)
     dev: true
 
-  /call-bind/1.0.2:
+  /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.2.0
     dev: false
 
-  /camelcase-css/2.0.1:
+  /camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
     dev: true
 
-  /caniuse-lite/1.0.30001451:
+  /caniuse-lite@1.0.30001451:
     resolution: {integrity: sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==}
     dev: true
 
-  /canvg/4.0.1:
-    resolution: {integrity: sha512-5gD/d6SiCCT7baLnVr0hokYe93DfcHW2rSqdKOuOQD84YMlyfttnZ8iQsThTdX6koYam+PROz/FuQTo500zqGw==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@types/offscreencanvas': 2019.7.0
-      '@types/raf': 3.4.0
-      raf: 3.4.1
-      rgbcolor: 1.0.1
-      stackblur-canvas: 2.5.0
-      svg-pathdata: 6.0.3
-    dev: false
-
-  /chokidar/3.5.3:
+  /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
     dependencies:
@@ -1147,25 +1136,25 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /clone/2.1.2:
+  /clone@2.1.2:
     resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
     dev: false
 
-  /color-name/1.1.4:
+  /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
-  /cssesc/3.0.0:
+  /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
     dev: true
 
-  /csstype/2.6.21:
+  /csstype@2.6.21:
     resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
 
-  /deep-equal/1.1.1:
+  /deep-equal@1.1.1:
     resolution: {integrity: sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==}
     dependencies:
       is-arguments: 1.1.1
@@ -1176,12 +1165,12 @@ packages:
       regexp.prototype.flags: 1.4.3
     dev: false
 
-  /deepmerge/4.3.0:
+  /deepmerge@4.3.0:
     resolution: {integrity: sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==}
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /define-properties/1.1.4:
+  /define-properties@1.1.4:
     resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1189,11 +1178,11 @@ packages:
       object-keys: 1.1.1
     dev: false
 
-  /defined/1.0.1:
+  /defined@1.0.1:
     resolution: {integrity: sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==}
     dev: true
 
-  /detective/5.2.1:
+  /detective@5.2.1:
     resolution: {integrity: sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==}
     engines: {node: '>=0.8.0'}
     hasBin: true
@@ -1203,19 +1192,19 @@ packages:
       minimist: 1.2.7
     dev: true
 
-  /didyoumean/1.2.2:
+  /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
     dev: true
 
-  /dlv/1.1.3:
+  /dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: true
 
-  /electron-to-chromium/1.4.292:
+  /electron-to-chromium@1.4.292:
     resolution: {integrity: sha512-ESWOSyJy5odDlE8wvh5NNAMORv4r6assPwIPGHEMWrWD0SONXcG/xT+9aD9CQyeRwyYDPo6dJT4Bbeg5uevVQQ==}
     dev: true
 
-  /esbuild/0.16.17:
+  /esbuild@0.16.17:
     resolution: {integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==}
     engines: {node: '>=12'}
     hasBin: true
@@ -1245,27 +1234,27 @@ packages:
       '@esbuild/win32-x64': 0.16.17
     dev: true
 
-  /escalade/3.1.1:
+  /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
     dev: true
 
-  /estree-walker/2.0.2:
+  /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
-  /eventemitter3/2.0.3:
+  /eventemitter3@2.0.3:
     resolution: {integrity: sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==}
     dev: false
 
-  /extend/3.0.2:
+  /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
     dev: false
 
-  /fast-diff/1.1.2:
+  /fast-diff@1.1.2:
     resolution: {integrity: sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==}
     dev: false
 
-  /fast-glob/3.2.12:
+  /fast-glob@3.2.12:
     resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
     engines: {node: '>=8.6.0'}
     dependencies:
@@ -1276,28 +1265,28 @@ packages:
       micromatch: 4.0.5
     dev: true
 
-  /fastq/1.15.0:
+  /fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
       reusify: 1.0.4
     dev: true
 
-  /fill-range/7.0.1:
+  /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
     dev: true
 
-  /flatpickr/4.6.13:
+  /flatpickr@4.6.13:
     resolution: {integrity: sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==}
     dev: false
 
-  /fraction.js/4.2.0:
+  /fraction.js@4.2.0:
     resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
     dev: true
 
-  /fsevents/2.3.2:
+  /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
@@ -1305,14 +1294,14 @@ packages:
     dev: true
     optional: true
 
-  /function-bind/1.1.1:
+  /function-bind@1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
 
-  /functions-have-names/1.2.3:
+  /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: false
 
-  /get-intrinsic/1.2.0:
+  /get-intrinsic@1.2.0:
     resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
     dependencies:
       function-bind: 1.1.1
@@ -1320,45 +1309,49 @@ packages:
       has-symbols: 1.0.3
     dev: false
 
-  /glob-parent/5.1.2:
+  /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
     dev: true
 
-  /glob-parent/6.0.2:
+  /glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
     dependencies:
       is-glob: 4.0.3
     dev: true
 
-  /has-property-descriptors/1.0.0:
+  /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
       get-intrinsic: 1.2.0
     dev: false
 
-  /has-symbols/1.0.3:
+  /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
     dev: false
 
-  /has-tostringtag/1.0.0:
+  /has-tostringtag@1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
     dev: false
 
-  /has/1.0.3:
+  /has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
 
-  /is-arguments/1.1.1:
+  /html-to-image@1.11.11:
+    resolution: {integrity: sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==}
+    dev: false
+
+  /is-arguments@1.1.1:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1366,44 +1359,44 @@ packages:
       has-tostringtag: 1.0.0
     dev: false
 
-  /is-binary-path/2.1.0:
+  /is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
     dev: true
 
-  /is-core-module/2.11.0:
+  /is-core-module@2.11.0:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
     dev: true
 
-  /is-date-object/1.0.5:
+  /is-date-object@1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
     dev: false
 
-  /is-extglob/2.1.1:
+  /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /is-glob/4.0.3:
+  /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
     dev: true
 
-  /is-number/7.0.0:
+  /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
     dev: true
 
-  /is-regex/1.1.4:
+  /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1411,26 +1404,26 @@ packages:
       has-tostringtag: 1.0.0
     dev: false
 
-  /jsbarcode/3.11.5:
+  /jsbarcode@3.11.5:
     resolution: {integrity: sha512-zv3KsH51zD00I/LrFzFSM6dst7rDn0vIMzaiZFL7qusTjPZiPtxg3zxetp0RR7obmjTw4f6NyGgbdkBCgZUIrA==}
     hasBin: true
     dev: false
 
-  /kjua/0.9.0:
+  /kjua@0.9.0:
     resolution: {integrity: sha512-Wmh5k6hpl+wiYkcEIx0/Ocj1DOxacw/myh/SQ3NbY0RWD4360CXaaAJkdeeV+moqf7fxvACYK95LXQ8vtLWKxA==}
     dev: false
 
-  /lilconfig/2.0.6:
+  /lilconfig@2.0.6:
     resolution: {integrity: sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==}
     engines: {node: '>=10'}
     dev: true
 
-  /magic-string/0.25.9:
+  /magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
 
-  /material-components-web/15.0.0-canary.d9f821042.0:
+  /material-components-web@15.0.0-canary.d9f821042.0:
     resolution: {integrity: sha512-suRteTaHJtF+Z2MRiiZJwcJ/7aKXZPkM/ugJXwL2iDSFd0JXZoydLmw1OWBQR/h5zM4iMnm05PExBZNYnkMBjA==}
     dependencies:
       '@material/animation': 15.0.0-canary.d9f821042.0
@@ -1485,12 +1478,12 @@ packages:
       '@material/typography': 15.0.0-canary.d9f821042.0
     dev: false
 
-  /merge2/1.4.1:
+  /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
     dev: true
 
-  /micromatch/4.0.5:
+  /micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
     dependencies:
@@ -1498,39 +1491,39 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /minimist/1.2.7:
+  /minimist@1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
     dev: true
 
-  /moment/2.29.4:
+  /moment@2.29.4:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
     dev: false
 
-  /nanoid/3.3.4:
+  /nanoid@3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  /node-releases/2.0.10:
+  /node-releases@2.0.10:
     resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
     dev: true
 
-  /normalize-path/3.0.0:
+  /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /normalize-range/0.1.2:
+  /normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /object-hash/3.0.0:
+  /object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
     dev: true
 
-  /object-is/1.1.5:
+  /object-is@1.1.5:
     resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1538,37 +1531,33 @@ packages:
       define-properties: 1.1.4
     dev: false
 
-  /object-keys/1.1.1:
+  /object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
     dev: false
 
-  /parchment/1.1.4:
+  /parchment@1.1.4:
     resolution: {integrity: sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==}
     dev: false
 
-  /path-parse/1.0.7:
+  /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
 
-  /performance-now/2.1.0:
-    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
-    dev: false
-
-  /picocolors/1.0.0:
+  /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
-  /picomatch/2.3.1:
+  /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
     dev: true
 
-  /pify/2.3.0:
+  /pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /postcss-import/14.1.0_postcss@8.4.21:
+  /postcss-import@14.1.0(postcss@8.4.21):
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -1580,7 +1569,7 @@ packages:
       resolve: 1.22.1
     dev: true
 
-  /postcss-js/4.0.1_postcss@8.4.21:
+  /postcss-js@4.0.1(postcss@8.4.21):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
@@ -1590,7 +1579,7 @@ packages:
       postcss: 8.4.21
     dev: true
 
-  /postcss-load-config/3.1.4_postcss@8.4.21:
+  /postcss-load-config@3.1.4(postcss@8.4.21):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -1607,7 +1596,7 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /postcss-nested/6.0.0_postcss@8.4.21:
+  /postcss-nested@6.0.0(postcss@8.4.21):
     resolution: {integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==}
     engines: {node: '>=12.0'}
     peerDependencies:
@@ -1617,7 +1606,7 @@ packages:
       postcss-selector-parser: 6.0.11
     dev: true
 
-  /postcss-selector-parser/6.0.11:
+  /postcss-selector-parser@6.0.11:
     resolution: {integrity: sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==}
     engines: {node: '>=4'}
     dependencies:
@@ -1625,11 +1614,11 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /postcss-value-parser/4.2.0:
+  /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
-  /postcss/8.4.21:
+  /postcss@8.4.21:
     resolution: {integrity: sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
@@ -1637,16 +1626,16 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  /queue-microtask/1.2.3:
+  /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
-  /quick-lru/5.1.1:
+  /quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
     dev: true
 
-  /quill-delta/3.6.3:
+  /quill-delta@3.6.3:
     resolution: {integrity: sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==}
     engines: {node: '>=0.10'}
     dependencies:
@@ -1655,7 +1644,7 @@ packages:
       fast-diff: 1.1.2
     dev: false
 
-  /quill/1.3.7:
+  /quill@1.3.7:
     resolution: {integrity: sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==}
     dependencies:
       clone: 2.1.2
@@ -1666,26 +1655,20 @@ packages:
       quill-delta: 3.6.3
     dev: false
 
-  /raf/3.4.1:
-    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
-    dependencies:
-      performance-now: 2.1.0
-    dev: false
-
-  /read-cache/1.0.0:
+  /read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
     dependencies:
       pify: 2.3.0
     dev: true
 
-  /readdirp/3.6.0:
+  /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
     dev: true
 
-  /regexp.prototype.flags/1.4.3:
+  /regexp.prototype.flags@1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1694,7 +1677,7 @@ packages:
       functions-have-names: 1.2.3
     dev: false
 
-  /resolve/1.22.1:
+  /resolve@1.22.1:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
@@ -1703,17 +1686,12 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
-  /reusify/1.0.4:
+  /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: true
 
-  /rgbcolor/1.0.1:
-    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
-    engines: {node: '>= 0.8.15'}
-    dev: false
-
-  /rollup/3.14.0:
+  /rollup@3.14.0:
     resolution: {integrity: sha512-o23sdgCLcLSe3zIplT9nQ1+r97okuaiR+vmAPZPTDYB7/f3tgWIYNyiQveMsZwshBT0is4eGax/HH83Q7CG+/Q==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
@@ -1721,44 +1699,34 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /run-parallel/1.2.0:
+  /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
     dev: true
 
-  /safevalues/0.3.4:
+  /safevalues@0.3.4:
     resolution: {integrity: sha512-LRneZZRXNgjzwG4bDQdOTSbze3fHm1EAKN/8bePxnlEZiBmkYEDggaHbuvHI9/hoqHbGfsEA7tWS9GhYHZBBsw==}
     dev: false
 
-  /source-map-js/1.0.2:
+  /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
-  /source-map/0.6.1:
+  /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
-  /sourcemap-codec/1.4.8:
+  /sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     deprecated: Please use @jridgewell/sourcemap-codec instead
 
-  /stackblur-canvas/2.5.0:
-    resolution: {integrity: sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==}
-    engines: {node: '>=0.1.14'}
-    dev: false
-
-  /supports-preserve-symlinks-flag/1.0.0:
+  /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
 
-  /svg-pathdata/6.0.3:
-    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
-    engines: {node: '>=12.0.0'}
-    dev: false
-
-  /tailwindcss/3.2.4_postcss@8.4.21:
+  /tailwindcss@3.2.4(postcss@8.4.21):
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -1780,10 +1748,10 @@ packages:
       object-hash: 3.0.0
       picocolors: 1.0.0
       postcss: 8.4.21
-      postcss-import: 14.1.0_postcss@8.4.21
-      postcss-js: 4.0.1_postcss@8.4.21
-      postcss-load-config: 3.1.4_postcss@8.4.21
-      postcss-nested: 6.0.0_postcss@8.4.21
+      postcss-import: 14.1.0(postcss@8.4.21)
+      postcss-js: 4.0.1(postcss@8.4.21)
+      postcss-load-config: 3.1.4(postcss@8.4.21)
+      postcss-nested: 6.0.0(postcss@8.4.21)
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
@@ -1792,22 +1760,22 @@ packages:
       - ts-node
     dev: true
 
-  /to-fast-properties/2.0.0:
+  /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
 
-  /to-regex-range/5.0.1:
+  /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
     dev: true
 
-  /tslib/2.5.0:
+  /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: false
 
-  /update-browserslist-db/1.0.10_browserslist@4.21.5:
+  /update-browserslist-db@1.0.10(browserslist@4.21.5):
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
     hasBin: true
     peerDependencies:
@@ -1818,11 +1786,11 @@ packages:
       picocolors: 1.0.0
     dev: true
 
-  /util-deprecate/1.0.2:
+  /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /vite/4.1.1:
+  /vite@4.1.1:
     resolution: {integrity: sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -1855,21 +1823,21 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vue/3.2.47:
+  /vue@3.2.47:
     resolution: {integrity: sha512-60188y/9Dc9WVrAZeUVSDxRQOZ+z+y5nO2ts9jWXSTkMvayiWxCWOWtBQoYjLeccfXkiiPZWAHcV+WTPhkqJHQ==}
     dependencies:
       '@vue/compiler-dom': 3.2.47
       '@vue/compiler-sfc': 3.2.47
       '@vue/runtime-dom': 3.2.47
-      '@vue/server-renderer': 3.2.47_vue@3.2.47
+      '@vue/server-renderer': 3.2.47(vue@3.2.47)
       '@vue/shared': 3.2.47
 
-  /xtend/4.0.2:
+  /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
     dev: true
 
-  /yaml/1.10.2:
+  /yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
     dev: true

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,7 +19,7 @@
             <div class="grid grid-flow-col mb-4 whitespace-pre-wrap break-keep">
             <ui-file class="col-span-2" accept="image/*" @change="balmUI.onChange('files', $event)"
               :text="files[0] ? '更换 / Change' :'选择头像 / Select Avator'"></ui-file>
-            <ui-button class="col-span-1" v-if="files[0]" outlined icon="download" @click="getDownload">保存 / Save</ui-button></div>
+            <ui-button class="col-span-1" outlined icon="download" @click="getDownload">保存 / Save</ui-button></div>
             <div class="w-full mt-5">
               <Readme></Readme>
             </div>
@@ -29,7 +29,7 @@
     </div>
     <div class="lg:w-4/12 xl:w-1/4 w-10/12 bg-zinc-100 border-solid border-x-8 border-white rounded-lg drop-shadow-2lg">
       <div class="justify-center mt-2">
-        <CardRender :surname="getAttrs['surname']" :givenname="getAttrs['givenname']" :position="getAttrs['position']"
+        <CardRender ref="uegWorkCardRef" :surname="getAttrs['surname']" :givenname="getAttrs['givenname']" :position="getAttrs['position']"
           :avator="getAttrs['avator']" />
       </div>
 
@@ -37,13 +37,11 @@
   </div>
 </template>
 
-
 <script>
 import CardRender from './components/CardRender.vue';
 import Readme from './components/Readme.vue';
 import { useEvent } from 'balm-ui';
-import cardcss from './card.css?inline'
-
+import * as htmlToImage from 'html-to-image';
 
 export default {
   data() {
@@ -75,34 +73,18 @@ export default {
   },
   methods: {
     async getDownload() {
-      let timenow = new Date().valueOf()
-      let filename = `${this.getAttrs['surname']}-${this.getAttrs['givenname']}-${timenow}.png`
-      const output = { "name": filename, "width": 2800, "height": 4000 }
-      let uegcard = document.querySelector('#ueg-card')
-      if (uegcard) {
-        uegcard = uegcard.cloneNode(true)
-        let cssNode = document.createElement('style')
-        cssNode.innerHTML = cardcss
-        uegcard.appendChild(cssNode)
-        const uriData = `data:image/svg+xml;base64,${btoa(new XMLSerializer().serializeToString(uegcard))}`
+      const timeNow = new Date().valueOf()
+      const filename = `${this.getAttrs['surname']}-${this.getAttrs['givenname']}-${timeNow}.png`
+      const uegWorkCardElement = this.$refs.uegWorkCardRef.$el
+      const imageOptions = {width:1984.3, height:2834.6}
 
-        const img = new Image()
-        img.src = uriData
-        img.onload = () => {
-          const canvas = document.createElement("canvas");
-          [canvas.width, canvas.height] = [output.width, output.height]
-          const ctx = canvas.getContext("2d")
-          ctx.drawImage(img, 0, 0, output.width, output.height)
-
-          // 👇 download
-          const a = document.createElement("a")
-          const quality = 1.0 // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingQuality
-          a.href = canvas.toDataURL("image/png", quality)
-          a.download = filename
-          a.append(canvas)
-          a.click()
-          a.remove()
-        }
+      if (uegWorkCardElement) {
+        const dataUrl = await htmlToImage.toPng(uegWorkCardElement, imageOptions);
+        const a = document.createElement('a');
+        a.href = dataUrl;
+        a.download = filename;
+        a.click();
+        a.remove();
       }
     }
   }


### PR DESCRIPTION
## Checklist
- [x] Completed all template sections below
- [x] Added a label to PR to specify the type

## Overview
In order to fix the issue https://github.com/United-Earth-Team/ueg-card-vue/issues/1.
I install a new deps [html-to-image](https://github.com/bubkoo/html-to-image) to generate ueg work card image.

Besides, I also:
- Remove the if condition for `save` button, so it can allow user to download the default ueg work card image
- Remove an unsed deps `canvg`.
- And use `ref` instead of `document.getElementById`.


<!-- Describe your changes in detail -->

## Testing

- [ ] Includes additional automatic tests
- [x] Did manual tests

Did manual tests locally. 
<!-- Describe what tests you have added, as well as what manual testing have you done. -->

## Screenshots

### UI:

Before: 
![image](https://user-images.githubusercontent.com/65056401/234785900-b8e9c643-d1f8-421b-860e-6f8b84bc6dbd.png)

Present:
![image](https://user-images.githubusercontent.com/65056401/234785403-b079d681-e54e-4a32-933f-0a6704bb0c76.png)

### Generated Image:

Before:
![image](https://user-images.githubusercontent.com/65056401/234786106-e72a2325-c13a-4cbc-b54a-20e0e00716b5.png)

Present:
![image](https://user-images.githubusercontent.com/65056401/234785499-070ded17-dcf9-456b-9495-8bdd15267bf7.png)

<!-- If possible, provide relevant screenshots or videos of the new functionality - and possibly the old. -->